### PR TITLE
remove stdlib setting

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,7 +16,7 @@
       "<!(node -e \"require('nan')\")"
     ],
     "xcode_settings": {
-      "OTHER_CPLUSPLUSFLAGS": ["-std=c++11", "-stdlib=libc++", "-mmacosx-version-min=10.8"],
+      "OTHER_CPLUSPLUSFLAGS": ["-mmacosx-version-min=10.8"],
       "OTHER_LDFLAGS": ["-framework CoreFoundation -framework IOKit -framework AppKit"]
     }
   }]


### PR DESCRIPTION
Attempted to build with Electron 11.4.8 and ran into 
```
error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
            !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                ~~~~~^~~~~~~~~~~
                                     remove_cv
```
Copying solution from https://github.com/microsoft/node-pty/pull/433
